### PR TITLE
Fix profile tab breaking other tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -891,6 +891,9 @@
                 <button id="back-to-index" class="accent back-button"><i class="fas fa-arrow-left"></i> Back to Index</button>
                 <div class="lyric-detail-container" id="lyric-detail-content"></div>
             </div>
+
+			<!-- Profile View -->
+			<div id="profile-view" class="hidden"></div>
         </div>
     </div>
 
@@ -2205,10 +2208,11 @@
             });
             document.querySelector(`[data-tab="${tab}"]`).classList.add('active');
             
-            // Hide all content
-            document.getElementById('admin-controls').classList.add('hidden');
-            document.getElementById('viewer-content').classList.add('hidden');
-            document.getElementById('lyric-detail-view').classList.add('hidden');
+			// Hide all content
+			document.getElementById('admin-controls').classList.add('hidden');
+			document.getElementById('viewer-content').classList.add('hidden');
+			document.getElementById('lyric-detail-view').classList.add('hidden');
+			document.getElementById('profile-view').classList.add('hidden');
             
             // Show appropriate content
             if (tab === 'admin' && currentUser && currentUser.email === 'simsonpeter@gmail.com') {
@@ -2216,56 +2220,56 @@
                 document.querySelector('.tab[data-tab="song-index"]').click();
             } else if (tab === 'songs' || tab === 'search') {
                 document.getElementById('viewer-content').classList.remove('hidden');
-            } else if (tab === 'profile') {
-                // Show user profile info
-                showProfile();
+			} else if (tab === 'profile') {
+				// Show user profile info
+				showProfile();
             }
         }
 
-        // Show profile information
-        function showProfile() {
-            const viewerContent = document.getElementById('viewer-content');
-            viewerContent.innerHTML = `
-                <div class="lyric-form">
-                    <h2><i class="fas fa-user"></i> Profile</h2>
-                    <div class="form-group">
-                        <label>Email</label>
-                        <input type="text" value="${currentUser?.email || 'Not logged in'}" readonly>
-                    </div>
-                    <div class="form-group">
-                        <label>Last Sync</label>
-                        <input type="text" id="last-sync-time" readonly>
-                    </div>
-                    <div class="form-group">
-                        <label>Local Songs</label>
-                        <input type="text" id="local-song-count" readonly>
-                    </div>
-                    <div class="lyric-actions">
-                        <button id="profile-sync-btn" class="sync-button">
-                            <i class="fas fa-sync-alt"></i>
-                            <span>Sync Now</span>
-                        </button>
-                        <button id="profile-logout-btn" class="accent">
-                            <i class="fas fa-sign-out-alt"></i>
-                            <span>Sign Out</span>
-                        </button>
-                    </div>
-                </div>
-            `;
-            
-            // Load profile data
-            loadProfileData();
-            
-            // Add event listeners
-            document.getElementById('profile-sync-btn').addEventListener('click', manualSync);
-            document.getElementById('profile-logout-btn').addEventListener('click', () => {
-                auth.signOut().catch(error => {
-                    alert('Logout error: ' + error.message);
-                });
-            });
-            
-            viewerContent.classList.remove('hidden');
-        }
+		// Show profile information
+		function showProfile() {
+			const profileView = document.getElementById('profile-view');
+			profileView.innerHTML = `
+				<div class="lyric-form">
+					<h2><i class="fas fa-user"></i> Profile</h2>
+					<div class="form-group">
+						<label>Email</label>
+						<input type="text" value="${currentUser?.email || 'Not logged in'}" readonly>
+					</div>
+					<div class="form-group">
+						<label>Last Sync</label>
+						<input type="text" id="last-sync-time" readonly>
+					</div>
+					<div class="form-group">
+						<label>Local Songs</label>
+						<input type="text" id="local-song-count" readonly>
+					</div>
+					<div class="lyric-actions">
+						<button id="profile-sync-btn" class="sync-button">
+							<i class="fas fa-sync-alt"></i>
+							<span>Sync Now</span>
+						</button>
+						<button id="profile-logout-btn" class="accent">
+							<i class="fas fa-sign-out-alt"></i>
+							<span>Sign Out</span>
+						</button>
+					</div>
+				</div>
+			`;
+			
+			// Load profile data
+			loadProfileData();
+			
+			// Add event listeners
+			document.getElementById('profile-sync-btn').addEventListener('click', manualSync);
+			document.getElementById('profile-logout-btn').addEventListener('click', () => {
+				auth.signOut().catch(error => {
+					alert('Logout error: ' + error.message);
+				});
+			});
+			
+			profileView.classList.remove('hidden');
+		}
 
         // Load profile data
         async function loadProfileData() {


### PR DESCRIPTION
Add a dedicated `profile-view` container and update tab switching logic to prevent the Profile tab from overwriting `viewer-content`.

The Profile tab was rendering its content into `viewer-content`, which is also used by the 'Songs' and 'Search' tabs. This caused other tabs to appear non-functional after the Profile tab was clicked, as their content area was being replaced.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd9133e3-7bb6-4f96-b774-f1e32ff3ccca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd9133e3-7bb6-4f96-b774-f1e32ff3ccca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

