### PR TITLE
Fetch song tab profile details

### DIFF
--- a/index.html
+++ b/index.html
@@ -878,6 +878,12 @@
             </div>
             
             <div id="viewer-content">
+                <div id="profile-badge" class="hidden" style="display:flex;gap:10px;align-items:center;margin-bottom:10px;">
+                    <i class="fas fa-user" style="color: var(--secondary-color);"></i>
+                    <span id="badge-email" style="font-weight:600;"></span>
+                    <span id="badge-sync" style="font-size:0.9rem;color:#666;"></span>
+                    <span id="badge-count" style="font-size:0.9rem;color:#666;"></span>
+                </div>
                 <div class="search-bar">
                     <input type="text" id="viewer-search-input" placeholder="Search songs...">
                 </div>
@@ -886,6 +892,7 @@
                     <div class="song-index" id="viewer-song-index"></div>
                 </div>
             </div>
+            <div id="profile-content" class="hidden"></div>
             
             <div id="lyric-detail-view" class="hidden">
                 <button id="back-to-index" class="accent back-button"><i class="fas fa-arrow-left"></i> Back to Index</button>
@@ -1039,6 +1046,31 @@
             });
         }
         
+        // Profile badge helpers
+        function hideProfileBadge() {
+            const badge = document.getElementById('profile-badge');
+            if (badge) badge.classList.add('hidden');
+        }
+
+        async function updateProfileBadge() {
+            const badge = document.getElementById('profile-badge');
+            if (!badge) return;
+            const emailEl = document.getElementById('badge-email');
+            const syncEl = document.getElementById('badge-sync');
+            const countEl = document.getElementById('badge-count');
+            const email = currentUser?.email || '';
+            const lastSync = await songDB.getLastSyncTime();
+            const songCount = await songDB.getSongCount();
+            if (!email) {
+                hideProfileBadge();
+                return;
+            }
+            emailEl.textContent = email;
+            syncEl.textContent = `• Last sync: ${lastSync ? new Date(lastSync).toLocaleString() : 'Never'}`;
+            countEl.textContent = `• Local songs: ${songCount}`;
+            badge.classList.remove('hidden');
+        }
+
         // Analyze songs to determine which Tamil letters are present
         function updateAvailableLetters() {
             availableLetters.clear();
@@ -1279,6 +1311,7 @@
                 document.querySelector('.tab[data-tab="song-index"]').click();
             } else {
                 viewerContent.classList.remove('hidden');
+                updateProfileBadge();
             }
         }
         
@@ -1325,6 +1358,9 @@
                     el.classList.remove('active');
                 }
             });
+
+            // Update profile badge after songs load
+            updateProfileBadge();
         }
         
         // Tab switching
@@ -2126,6 +2162,8 @@
                     syncText.textContent = 'Sync';
                 }
                 isSyncing = false;
+                // Update badge after sync completes
+                updateProfileBadge();
             }
         }
 
@@ -2208,24 +2246,31 @@
             // Hide all content
             document.getElementById('admin-controls').classList.add('hidden');
             document.getElementById('viewer-content').classList.add('hidden');
+            document.getElementById('profile-content').classList.add('hidden');
             document.getElementById('lyric-detail-view').classList.add('hidden');
             
             // Show appropriate content
             if (tab === 'admin' && currentUser && currentUser.email === 'simsonpeter@gmail.com') {
                 document.getElementById('admin-controls').classList.remove('hidden');
                 document.querySelector('.tab[data-tab="song-index"]').click();
-            } else if (tab === 'songs' || tab === 'search') {
+                hideProfileBadge();
+            } else if (tab === 'songs') {
                 document.getElementById('viewer-content').classList.remove('hidden');
+                updateProfileBadge();
+            } else if (tab === 'search') {
+                document.getElementById('viewer-content').classList.remove('hidden');
+                hideProfileBadge();
             } else if (tab === 'profile') {
                 // Show user profile info
                 showProfile();
+                hideProfileBadge();
             }
         }
 
         // Show profile information
         function showProfile() {
-            const viewerContent = document.getElementById('viewer-content');
-            viewerContent.innerHTML = `
+            const profileContent = document.getElementById('profile-content');
+            profileContent.innerHTML = `
                 <div class="lyric-form">
                     <h2><i class="fas fa-user"></i> Profile</h2>
                     <div class="form-group">
@@ -2264,7 +2309,7 @@
                 });
             });
             
-            viewerContent.classList.remove('hidden');
+            profileContent.classList.remove('hidden');
         }
 
         // Load profile data


### PR DESCRIPTION
Add a compact profile badge to the Songs tab to show key user details without leaving the song list, and separate the full profile view into its own section.

The previous implementation of `showProfile` would overwrite the `viewer-content` area, meaning the Songs tab content would disappear when viewing the profile. This change introduces a dedicated `profile-content` section for the full profile view and a smaller `profile-badge` within the `viewer-content` for the Songs tab, allowing users to see essential profile information (email, last sync, song count) while browsing songs, and preventing content overlap.

---
<a href="https://cursor.com/background-agent?bcId=bc-30a31c50-008c-4b9d-849f-981ea7f4faaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30a31c50-008c-4b9d-849f-981ea7f4faaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

