### PR TITLE
Adjust spacing between title and search

### DIFF
--- a/index.html
+++ b/index.html
@@ -803,7 +803,7 @@
         
         @media (max-width: 900px) {
             body {
-                padding-top: 200px;
+                padding-top: 60px;
             }
             
             .song-index {
@@ -859,7 +859,7 @@
         
         @media (max-width: 480px) {
             body {
-                padding-top: 220px;
+                padding-top: 60px;
             }
             
             .tabs {


### PR DESCRIPTION
Reduce excessive `body padding-top` in mobile media queries to remove the large gap below the header.

---
<a href="https://cursor.com/background-agent?bcId=bc-075765ec-c030-4c7a-ad1d-d0a43c228e92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-075765ec-c030-4c7a-ad1d-d0a43c228e92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

