### PR TITLE
Adjust search box position on scrollable page

### DIFF
--- a/index.html
+++ b/index.html
@@ -859,7 +859,7 @@
         
         @media (max-width: 480px) {
             body {
-                padding-top: 220px;
+                padding-top: 120px;
             }
             
             .tabs {


### PR DESCRIPTION
Reduce mobile `padding-top` on the `body` to eliminate the large gap between the title and the search box on small screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc26c39d-9727-4791-9e17-c5f1d78b15ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc26c39d-9727-4791-9e17-c5f1d78b15ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

