### PR TITLE
Address unresolved issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -2161,25 +2161,6 @@
             }
         });
         
-        document.getElementById('viewer-search-input').addEventListener('input', (e) => {
-            const searchTerm = e.target.value.toLowerCase();
-            if (searchTerm === '') {
-                currentLetter = '';
-                renderSongIndex('viewer-song-index');
-                document.querySelectorAll('#viewer-alphabet-index .alphabet-letter').forEach(el => {
-                    if (el.textContent === 'அனைத்தும்') {
-                        el.classList.add('active');
-                    } else {
-                        el.classList.remove('active');
-                    }
-                });
-            } else {
-                const filteredSongs = songs.filter(song => 
-                    song.songTitle.toLowerCase().includes(searchTerm)
-                );
-                renderFilteredSongs(filteredSongs, 'viewer-song-index');
-            }
-        });
         
         function renderFilteredSongs(filteredSongs, containerId) {
             const container = document.getElementById(containerId);


### PR DESCRIPTION
Remove duplicate event listener for viewer search input to resolve search functionality conflicts.

Removed a redundant event listener directly attached to the `viewer-search-input` element. This listener duplicated functionality already handled by the `setupViewerSearch()` function, leading to potential conflicts and issues with the viewer search functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd76be86-f6db-49d4-9243-52affb572aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd76be86-f6db-49d4-9243-52affb572aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

