### PR TITLE
Scrollable page content starts at top

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             padding: 0;
             background-color: #f5f5f5;
             color: #333;
-            padding-top: 60px;
+            padding-top: 80px;
             padding-bottom: 80px;
         }
         
@@ -803,7 +803,7 @@
         
         @media (max-width: 900px) {
             body {
-                padding-top: 200px;
+                padding-top: 120px;
             }
             
             .song-index {
@@ -859,7 +859,7 @@
         
         @media (max-width: 480px) {
             body {
-                padding-top: 220px;
+                padding-top: 140px;
             }
             
             .tabs {


### PR DESCRIPTION
Adjust `body` `padding-top` values to ensure scrollable content starts at the top of the page.

This resolves an issue where excessive `padding-top` (especially on mobile breakpoints) caused content to begin in the middle of the viewport, providing a better user experience by correctly positioning the content after the fixed header.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e4a87e8-dd5b-4fa9-9451-8aac801b4463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e4a87e8-dd5b-4fa9-9451-8aac801b4463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

