### PR TITLE
Scrollable page content starts at top

### DIFF
--- a/index.html
+++ b/index.html
@@ -2832,6 +2832,13 @@
         
         // Initialize
         window.onload = async () => {
+            // Force scroll position to top on load and disable automatic restoration
+            if ('scrollRestoration' in history) {
+                history.scrollRestoration = 'manual';
+            }
+            window.scrollTo(0, 0);
+            document.body.scrollTop = 0;
+            document.documentElement.scrollTop = 0;
             // Initialize database and service worker
             await initDatabase();
             await initServiceWorker();
@@ -2870,7 +2877,21 @@
             document.getElementById('bottom-nav').classList.remove('hidden');
             isInitialized = true;
             await loadSongs();
+            // Ensure we are at the very top after initial content render
+            window.requestAnimationFrame(() => {
+                window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+                document.body.scrollTop = 0;
+                document.documentElement.scrollTop = 0;
+            });
         };
+        // When navigating back/forward, ensure the page starts at the top
+        window.addEventListener('pageshow', (event) => {
+            if (event.persisted) {
+                window.scrollTo(0, 0);
+                document.body.scrollTop = 0;
+                document.documentElement.scrollTop = 0;
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
Force scroll position to the top on page load and navigation to prevent starting in the middle.

---
<a href="https://cursor.com/background-agent?bcId=bc-a41d8bbc-bfa8-4039-be05-2f8ecefbc245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a41d8bbc-bfa8-4039-be05-2f8ecefbc245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

