### PR TITLE
Fix top margin and content alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             padding: 0;
             background-color: #f5f5f5;
             color: #333;
-            padding-top: 60px;
+            padding-top: 50px;
             padding-bottom: 80px;
         }
         
@@ -803,7 +803,7 @@
         
         @media (max-width: 900px) {
             body {
-                padding-top: 200px;
+                padding-top: 80px;
             }
             
             .song-index {
@@ -859,7 +859,7 @@
         
         @media (max-width: 480px) {
             body {
-                padding-top: 220px;
+                padding-top: 90px;
             }
             
             .tabs {


### PR DESCRIPTION
Reduce `padding-top` on the `body` element to fix content starting in the middle of the page.

The previous `padding-top` values, especially for tablet and mobile media queries (200px and 220px), were excessively pushing content down the viewport, making it appear as if the content started in the middle of the page. This change adjusts these values to provide appropriate spacing for the fixed header while ensuring content is visible at the top.

---
<a href="https://cursor.com/background-agent?bcId=bc-69b302b1-2acd-4284-9e75-29e82aafb7e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69b302b1-2acd-4284-9e75-29e82aafb7e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

