### PR TITLE
Fix top margin and content alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -859,7 +859,7 @@
         
         @media (max-width: 480px) {
             body {
-                padding-top: 220px;
+                padding-top: 70px;
             }
             
             .tabs {


### PR DESCRIPTION
Reduce `body` top padding on small screens to fix content starting in the middle of the page.

The previous `padding-top: 220px` for mobile screens was excessive, causing content to appear far down the page, especially on song lists and individual song pages, as the fixed header was only about 60px tall. This change aligns the padding with the header height, ensuring content starts near the top.

---
<a href="https://cursor.com/background-agent?bcId=bc-478ad25f-b077-415a-a804-fabe7f3b9445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-478ad25f-b077-415a-a804-fabe7f3b9445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

